### PR TITLE
Add Thread-Safe Proxy Factory Workaround

### DIFF
--- a/src/main/java/org/example/concurrentmodificationexception/config/SecurityConfig.java
+++ b/src/main/java/org/example/concurrentmodificationexception/config/SecurityConfig.java
@@ -1,20 +1,15 @@
 package org.example.concurrentmodificationexception.config;
 
 import java.util.ArrayList;
-import java.util.List;
-import org.springframework.beans.factory.config.BeanDefinition;
+
+import org.springframework.aop.Advisor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Role;
-import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.security.authorization.method.AuthorizationAdvisor;
 import org.springframework.security.authorization.method.AuthorizationAdvisorProxyFactory;
-import org.springframework.security.authorization.method.AuthorizationManagerAfterMethodInterceptor;
-import org.springframework.security.authorization.method.AuthorizationManagerBeforeMethodInterceptor;
 import org.springframework.security.authorization.method.AuthorizeReturnObjectMethodInterceptor;
-import org.springframework.security.authorization.method.PostFilterAuthorizationMethodInterceptor;
-import org.springframework.security.authorization.method.PreFilterAuthorizationMethodInterceptor;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -32,27 +27,16 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
-  @Primary
+
   @Bean
-  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-  static AuthorizationAdvisorProxyFactory proxyFactory() {
-    AuthorizationAdvisorProxyFactory proxyFactory =
-        new AuthorizationAdvisorProxyFactory(new ArrayList<>());
-    List<AuthorizationAdvisor> advisors = new ArrayList<>();
-
-    advisors.add(AuthorizationManagerBeforeMethodInterceptor.preAuthorize());
-    advisors.add(AuthorizationManagerAfterMethodInterceptor.postAuthorize());
-    advisors.add(new PreFilterAuthorizationMethodInterceptor());
-    advisors.add(new PostFilterAuthorizationMethodInterceptor());
-    advisors.add(new AuthorizeReturnObjectMethodInterceptor(proxyFactory));
-
-    AnnotationAwareOrderComparator.sort(advisors);
-
-    for (AuthorizationAdvisor advisor : advisors) {
-      proxyFactory.addAdvisor(advisor);
-    }
-
-    return proxyFactory;
+  @Role(2)
+  static Advisor authorizeReturnObjectAdvisor(ObjectProvider<AuthorizationAdvisor> provider, ThreadsafeAuthorizationProxyFactory proxyFactory) {
+    AuthorizationAdvisorProxyFactory delegate = new AuthorizationAdvisorProxyFactory(new ArrayList<>());
+    provider.forEach(delegate::addAdvisor);
+    AuthorizeReturnObjectMethodInterceptor interceptor = new AuthorizeReturnObjectMethodInterceptor(proxyFactory);
+    delegate.addAdvisor(interceptor);
+    proxyFactory.setDelegate(delegate);
+    return interceptor;
   }
 
   @Bean

--- a/src/main/java/org/example/concurrentmodificationexception/config/ThreadsafeAuthorizationProxyFactory.java
+++ b/src/main/java/org/example/concurrentmodificationexception/config/ThreadsafeAuthorizationProxyFactory.java
@@ -1,0 +1,30 @@
+package org.example.concurrentmodificationexception.config;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.authorization.AuthorizationProxyFactory;
+import org.springframework.security.authorization.method.AuthorizationAdvisorProxyFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+@Primary
+public class ThreadsafeAuthorizationProxyFactory implements AuthorizationProxyFactory {
+	private AuthorizationAdvisorProxyFactory delegate;
+
+	private final ReentrantLock lock = new ReentrantLock();
+
+	@Override
+	public Object proxy(Object object) {
+		try {
+			this.lock.lock();
+			return this.delegate.proxy(object);
+		} finally {
+			this.lock.unlock();
+		}
+	}
+
+	public void setDelegate(AuthorizationAdvisorProxyFactory delegate) {
+		this.delegate = delegate;
+	}
+}

--- a/src/main/java/org/example/concurrentmodificationexception/controller/Controller.java
+++ b/src/main/java/org/example/concurrentmodificationexception/controller/Controller.java
@@ -2,12 +2,14 @@ package org.example.concurrentmodificationexception.controller;
 
 import org.example.concurrentmodificationexception.model.InnerModel;
 import org.example.concurrentmodificationexception.model.Model;
+
 import org.springframework.security.authorization.method.AuthorizeReturnObject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class Controller {
+
   @AuthorizeReturnObject
   @GetMapping("/model")
   public Model getModel() {

--- a/src/test/java/org/example/concurrentmodificationexception/ConcurrentModificationExceptionTest.java
+++ b/src/test/java/org/example/concurrentmodificationexception/ConcurrentModificationExceptionTest.java
@@ -48,4 +48,11 @@ class ConcurrentModificationExceptionTest {
 
     futures.forEach(CompletableFuture::join);
   }
+
+  @Test
+  void authorizeReturnObjectWorks() throws Exception {
+      this.mockMvc.perform(get("/model")
+          .accept(MediaType.APPLICATION_JSON)
+          .with(user("user"))).andExpect(status().is5xxServerError());
+  }
 }


### PR DESCRIPTION
Even when a list requires no sorting, List.sort keeps track of each sort invocation as a change. When two different threads have a different change modification count, then a ConcurrentModificationException is thrown

To work around that, this commit adds a thread-safe wrapper around AuthorizationAdvisorProxyFactory and provides that wrapper to the method advice.